### PR TITLE
Feat/create http server

### DIFF
--- a/.github/PR_TEMPLATE/pr_template.md
+++ b/.github/PR_TEMPLATE/pr_template.md
@@ -36,6 +36,3 @@
 - [ ] All tests (previous and new) pass 🥳
 - [ ] This PR includes a Migration and I have notified the PM so they can run the migration after the PR is merged.
 <!--- Delete any above that do not apply to this PR -->
-
-### How to QA this change:
-<!--- Outline the steps needed to locally verify the implemented changes are working as intended -->

--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
 <!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
 <a id="readme-top"></a>
 <!--
-*** Thanks for checking out the Best-README-Template. If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
+
 
 
 
@@ -58,44 +53,38 @@
   <ol>
     <li>
       <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#built-with">Built With</a></li>
-      </ul>
     </li>
     <li>
       <a href="#getting-started">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
         <li><a href="#installation">Installation</a></li>
+        <li><a href="#run">Run</a></li>
       </ul>
     </li>
     <li><a href="#usage">Usage</a></li>
-    <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
-* [![JQuery][JQuery.com]][JQuery-url]
+</details>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+
+<!-- ABOUT THE PROJECT -->
+## About the project
 
 
 <!-- GETTING STARTED -->
 ## Getting Started
 
-This is an example of how you may give instructions on setting up your project locally.
-To get a local copy up and running follow these simple example steps.
-
 ### Prerequisites
 
-This is an example of how to list things you need to use the software and how to install them.
-* npm
-  ```sh
-  npm install npm@latest -g
-  ```
+This is application is run on go version 1.24.0.
+- Use [this link](https://go.dev/doc/install) to learn more about installing Go locally.
 
 ### Installation
 
-_Below is an example of how you can instruct your audience on installing and setting up your app. This template doesn't rely on any external dependencies or services._
+<!-- _Below is an example of how you can instruct your audience on installing and setting up your app. This template doesn't rely on any external dependencies or services._
 
 1. Get a free API Key at [https://example.com](https://example.com)
 2. Clone the repo
@@ -114,7 +103,18 @@ _Below is an example of how you can instruct your audience on installing and set
    ```sh
    git remote set-url origin github_username/repo_name
    git remote -v # confirm the changes
-   ```
+   ``` -->
+
+### Run
+
+To start a local HTTP server you can run this command in your terminal.
+```bash
+go run cmd/api/main.go
+```
+You will see this message logged in the terminal if this step is successful.
+```bash
+Server is running on port 8080
+```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -128,24 +128,6 @@ Use this space to show useful examples of how a project can be used. Additional 
 _For more examples, please refer to the [Documentation](https://example.com)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- ROADMAP -->
-## Roadmap
-
-- [x] Add Changelog
-- [x] Add back to top links
-- [ ] Add Additional Templates w/ Examples
-- [ ] Add "components" document to easily copy & paste sections of the readme
-- [ ] Multi-language Support
-    - [ ] Chinese
-    - [ ] Spanish
-
-See the [open issues](https://github.com/othneildrew/Best-README-Template/issues) for a full list of proposed features (and known issues).
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
 
 
 <!-- CONTRIBUTING -->

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Server is running! 🚀"))
+	})
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: mux,
+	}
+
+	log.Printf("Server is running on port %s", port)
+
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module historyHunters
+
+go 1.24.0


### PR DESCRIPTION
### Type of Change
- [x] feature ⛲
- [x] documentation update 📃

### Description
This PR creates a `main.go` file which runs a local instance of the server.  It defines a specific fall back port (8080), while allowing the future implementation of environmental variables to hold a port value. It utilizes the `net/http` standard library to create a Mux which routes to the standard access point of the server. The implementation includes a graceful exit strategy as well.

### Share the reason(s) for this pull request
Creating the HTTP server in the main file will allow the application to initialize the server when run. Thanks to the graceful exit 

### Related Tickets
closes #3 

### Screenshots (if applicable):

### Added Test?
- [x] No 🙅



### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] All tests (previous and new) pass 🥳
